### PR TITLE
Remove beta endpoints support in 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,6 @@ Version | Property | Type | Descripstion
 1.0 | *file_system_snapshots* | [**FileSystemSnapshots1dot0Api**](docs/FileSystemSnapshots1dot0Api.md) | API for the file system snapshots endpoint (**create** and **list**) |
 
 
-#### **Beta Endpoints**
-
-Third, there are beta APIs that are not guaranteed to work.
-
-Property | Type | Descripstion
------------- | ------------- | -------------
-*file_system_beta* | [**FileSystemsBetaApi**](docs/FileSystemsBetaApi.md) | API for the beta file system endpoint  (**delete** only) |
-*file_system_snapshot_beta* | [**FileSystemSnapshotsBetaApi**](docs/FileSystemSnapshotsBetaApi.md) | API for the beta file system snapshots endpoint (**delete** only) |
-
-
 #### Call with HTTP information
 Every method of each endpoint returns an object representing the body of the response from the server.
 If other information such as response status code or response header is needed, the corresponding method 

--- a/docs/FileSystemSnapshots1dot1Api.md
+++ b/docs/FileSystemSnapshots1dot1Api.md
@@ -81,7 +81,7 @@ except rest.ApiException as e:
 if res:
     try:
         # delete a file system snapshot named myfs.mysnap
-        fb.file_system_snapshots_beta.delete_file_system_snapshots(name="myfs.mysnap")
+        fb.file_system_snapshots.delete_file_system_snapshots(name="myfs.mysnap")
     except rest.ApiException as e:
         print("Exception when deleting file system snapshots: %s\n" % e)
 ```

--- a/docs/FileSystems1dot1Api.md
+++ b/docs/FileSystems1dot1Api.md
@@ -79,7 +79,7 @@ except rest.ApiException as e:
 if res:
     try:
         # delete a file system with name myfs
-        fb.file_systems_beta.delete_file_systems(name="myfs")
+        fb.file_systems.delete_file_systems(name="myfs")
     except rest.ApiException as e:
         print("Exception when deleting file system: %s\n" % e)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,16 +162,6 @@ Version | Property | Type | Descripstion
 1.0 | *file_system_snapshots* | [**FileSystemSnapshots1dot0Api**](FileSystemSnapshots1dot0Api.md) | API for the file system snapshots endpoint (**create** and **list**) |
 
 
-#### **Beta Endpoints**
-
-Third, there are beta APIs that are not guaranteed to work.
-
-Property | Type | Descripstion
------------- | ------------- | -------------
-*file_system_beta* | [**FileSystemsBetaApi**](FileSystemsBetaApi.md) | API for the beta file system endpoint  (**delete** only) |
-*file_system_snapshot_beta* | [**FileSystemSnapshotsBetaApi**](FileSystemSnapshotsBetaApi.md) | API for the beta file system snapshots endpoint (**delete** only) |
-
-
 #### Call with HTTP information
 Every method of each endpoint returns an object representing the body of the response from the server.
 If other information such as response status code or response header is needed, the corresponding method 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,9 +12,6 @@ pages:
     - 1.1 APIs:
         - File Systems: FileSystems1dot1Api.md
         - File System snapshots: FileSystemSnapshots1dot1Api.md
-    - Beta APIs:
-        - File Systems (Beta): FileSystemsBetaApi.md
-        - File System Snapshots (Beta): FileSystemSnapshotsBetaApi.md
 - Models:
     - Response:
         - Pagination Information: PaginationInfo.md

--- a/purity_fb/__init__.py
+++ b/purity_fb/__init__.py
@@ -32,10 +32,8 @@ from .models.version_response import VersionResponse
 
 # import apis into sdk package
 from .apis.authentication_api import AuthenticationApi
-from .apis.file_system_snapshots_beta_api import FileSystemSnapshotsBetaApi
 from .apis.file_system_snapshots_1dot0_api import FileSystemSnapshots1dot0Api
 from .apis.file_system_snapshots_1dot1_api import FileSystemSnapshots1dot1Api
-from .apis.file_systems_beta_api import FileSystemsBetaApi
 from .apis.file_systems_1dot0_api import FileSystems1dot0Api
 from .apis.file_systems_1dot1_api import FileSystems1dot1Api
 from .apis.version_api import VersionApi

--- a/purity_fb/api.py
+++ b/purity_fb/api.py
@@ -34,8 +34,6 @@ class PurityFb:
         self._file_system_snapshots = globals()[self._class_name(FILE_SYSTEM_SNAPSHOTS, self._version)](
             api_client=self._api_client)
 
-        self._file_systems_beta = FileSystemsBetaApi(api_client=self._api_client)
-        self._file_system_snapshots_beta = FileSystemSnapshotsBetaApi(api_client=self._api_client)
         if api_token:
             self.login(api_token)
         self.enable_verify_ssl()
@@ -124,11 +122,3 @@ class PurityFb:
     @property
     def file_system_snapshots(self):
         return self._file_system_snapshots
-
-    @property
-    def file_systems_beta(self):
-        return self._file_systems_beta
-
-    @property
-    def file_system_snapshots_beta(self):
-        return self._file_system_snapshots_beta

--- a/purity_fb/apis/__init__.py
+++ b/purity_fb/apis/__init__.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 # import apis into api package
 from .authentication_api import AuthenticationApi
-from .file_system_snapshots_beta_api import FileSystemSnapshotsBetaApi
 from .file_system_snapshots_1dot0_api import FileSystemSnapshots1dot0Api
 from .file_system_snapshots_1dot1_api import FileSystemSnapshots1dot1Api
-from .file_systems_beta_api import FileSystemsBetaApi
 from .file_systems_1dot0_api import FileSystems1dot0Api
 from .file_systems_1dot1_api import FileSystems1dot1Api
 from .version_api import VersionApi


### PR DESCRIPTION
Since beta endpoints are officially removed from Purity//FB REST API 1.1, the support is removed from 1.1 client as well.