### PR TITLE
Remove all default usages in REST client models' spec

### DIFF
--- a/docs/AlertWatcher.md
+++ b/docs/AlertWatcher.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | name of the object (e.g., a file system or snapshot) | [optional] 
-**enabled** | **bool** | is email notification enabled? | [optional] [default to True]
+**enabled** | **bool** | is email notification enabled? Default true when adding a new watcher | [optional] 
 
 [[Back to Model list]](index.md#documentation-for-models) [[Back to API list]](index.md#endpoint-properties) [[Back to Overview]](index.md)
 

--- a/docs/FileSystem.md
+++ b/docs/FileSystem.md
@@ -5,9 +5,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | name of the object (e.g., a file system or snapshot) | [optional] 
 **created** | **int** | creation timestamp of the object | [optional] 
-**fast_remove_directory_enabled** | **bool** | is fast remove directory enabled? Modifiable. | [optional] [default to False]
-**provisioned** | **int** | the provisioned size of the file system in bytes. Modifiable | [optional] 
-**snapshot_directory_enabled** | **bool** | is snapshot directory enabled? Modifiable. | [optional] [default to False]
+**fast_remove_directory_enabled** | **bool** | is fast remove directory enabled? Modifiable. Default false when creating a new file-system | [optional] 
+**provisioned** | **int** | the provisioned size of the file system in bytes. Modifiable. Default 0 when creating a new file-system | [optional] 
+**snapshot_directory_enabled** | **bool** | is snapshot directory enabled? Modifiable. Default false when creating a new file-system | [optional] 
 **space** | [**Space**](Space.md) | the space specification of the file system | [optional] 
 **nfs** | [**NfsRule**](NfsRule.md) | NFS configuration. Modifiable. | [optional] 
 **http** | [**ProtocolRule**](ProtocolRule.md) | HTTP configuration. Modifiable. | [optional] 

--- a/docs/NfsRule.md
+++ b/docs/NfsRule.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enabled** | **bool** | is the protocol enabled? | [optional] [default to False]
+**enabled** | **bool** | is the protocol enabled? Default false when creating a new rule | [optional] 
 **rules** | **str** | NFS rules | [optional] 
 
 [[Back to Model list]](index.md#documentation-for-models) [[Back to API list]](index.md#endpoint-properties) [[Back to Overview]](index.md)

--- a/docs/ProtocolRule.md
+++ b/docs/ProtocolRule.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enabled** | **bool** | is the protocol enabled? | [optional] [default to False]
+**enabled** | **bool** | is the protocol enabled? Default false when creating a new rule | [optional] 
 
 [[Back to Model list]](index.md#documentation-for-models) [[Back to API list]](index.md#endpoint-properties) [[Back to Overview]](index.md)
 

--- a/docs/SmbRule.md
+++ b/docs/SmbRule.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enabled** | **bool** | is the protocol enabled? | [optional] [default to False]
-**acl_mode** | **str** | SMB ACL mode | [optional] [default to 'shared']
+**enabled** | **bool** | is the protocol enabled? Default false when creating a new rule | [optional] 
+**acl_mode** | **str** | SMB ACL mode. Default shared when creating a new rule. | [optional] 
 
 [[Back to Model list]](index.md#documentation-for-models) [[Back to API list]](index.md#endpoint-properties) [[Back to Overview]](index.md)
 

--- a/purity_fb/models/alert_watcher.py
+++ b/purity_fb/models/alert_watcher.py
@@ -40,7 +40,7 @@ class AlertWatcher(object):
         'enabled': 'enabled'
     }
 
-    def __init__(self, name=None, enabled=True):
+    def __init__(self, name=None, enabled=None):
         """
         AlertWatcher - a model defined in Swagger
         """
@@ -80,7 +80,7 @@ class AlertWatcher(object):
     def enabled(self):
         """
         Gets the enabled of this AlertWatcher.
-        is email notification enabled?
+        is email notification enabled? Default true when adding a new watcher
 
         :return: The enabled of this AlertWatcher.
         :rtype: bool
@@ -91,7 +91,7 @@ class AlertWatcher(object):
     def enabled(self, enabled):
         """
         Sets the enabled of this AlertWatcher.
-        is email notification enabled?
+        is email notification enabled? Default true when adding a new watcher
 
         :param enabled: The enabled of this AlertWatcher.
         :type: bool

--- a/purity_fb/models/file_system.py
+++ b/purity_fb/models/file_system.py
@@ -58,7 +58,7 @@ class FileSystem(object):
         'time_remaining': 'time_remaining'
     }
 
-    def __init__(self, name=None, created=None, fast_remove_directory_enabled=False, provisioned=None, snapshot_directory_enabled=False, space=None, nfs=None, http=None, smb=None, destroyed=None, time_remaining=None):
+    def __init__(self, name=None, created=None, fast_remove_directory_enabled=None, provisioned=None, snapshot_directory_enabled=None, space=None, nfs=None, http=None, smb=None, destroyed=None, time_remaining=None):
         """
         FileSystem - a model defined in Swagger
         """
@@ -148,7 +148,7 @@ class FileSystem(object):
     def fast_remove_directory_enabled(self):
         """
         Gets the fast_remove_directory_enabled of this FileSystem.
-        is fast remove directory enabled? Modifiable.
+        is fast remove directory enabled? Modifiable. Default false when creating a new file-system
 
         :return: The fast_remove_directory_enabled of this FileSystem.
         :rtype: bool
@@ -159,7 +159,7 @@ class FileSystem(object):
     def fast_remove_directory_enabled(self, fast_remove_directory_enabled):
         """
         Sets the fast_remove_directory_enabled of this FileSystem.
-        is fast remove directory enabled? Modifiable.
+        is fast remove directory enabled? Modifiable. Default false when creating a new file-system
 
         :param fast_remove_directory_enabled: The fast_remove_directory_enabled of this FileSystem.
         :type: bool
@@ -171,7 +171,7 @@ class FileSystem(object):
     def provisioned(self):
         """
         Gets the provisioned of this FileSystem.
-        the provisioned size of the file system in bytes. Modifiable
+        the provisioned size of the file system in bytes. Modifiable. Default 0 when creating a new file-system
 
         :return: The provisioned of this FileSystem.
         :rtype: int
@@ -182,7 +182,7 @@ class FileSystem(object):
     def provisioned(self, provisioned):
         """
         Sets the provisioned of this FileSystem.
-        the provisioned size of the file system in bytes. Modifiable
+        the provisioned size of the file system in bytes. Modifiable. Default 0 when creating a new file-system
 
         :param provisioned: The provisioned of this FileSystem.
         :type: int
@@ -194,7 +194,7 @@ class FileSystem(object):
     def snapshot_directory_enabled(self):
         """
         Gets the snapshot_directory_enabled of this FileSystem.
-        is snapshot directory enabled? Modifiable.
+        is snapshot directory enabled? Modifiable. Default false when creating a new file-system
 
         :return: The snapshot_directory_enabled of this FileSystem.
         :rtype: bool
@@ -205,7 +205,7 @@ class FileSystem(object):
     def snapshot_directory_enabled(self, snapshot_directory_enabled):
         """
         Sets the snapshot_directory_enabled of this FileSystem.
-        is snapshot directory enabled? Modifiable.
+        is snapshot directory enabled? Modifiable. Default false when creating a new file-system
 
         :param snapshot_directory_enabled: The snapshot_directory_enabled of this FileSystem.
         :type: bool

--- a/purity_fb/models/nfs_rule.py
+++ b/purity_fb/models/nfs_rule.py
@@ -40,7 +40,7 @@ class NfsRule(object):
         'rules': 'rules'
     }
 
-    def __init__(self, enabled=False, rules=None):
+    def __init__(self, enabled=None, rules=None):
         """
         NfsRule - a model defined in Swagger
         """
@@ -57,7 +57,7 @@ class NfsRule(object):
     def enabled(self):
         """
         Gets the enabled of this NfsRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :return: The enabled of this NfsRule.
         :rtype: bool
@@ -68,7 +68,7 @@ class NfsRule(object):
     def enabled(self, enabled):
         """
         Sets the enabled of this NfsRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :param enabled: The enabled of this NfsRule.
         :type: bool

--- a/purity_fb/models/protocol_rule.py
+++ b/purity_fb/models/protocol_rule.py
@@ -38,7 +38,7 @@ class ProtocolRule(object):
         'enabled': 'enabled'
     }
 
-    def __init__(self, enabled=False):
+    def __init__(self, enabled=None):
         """
         ProtocolRule - a model defined in Swagger
         """
@@ -52,7 +52,7 @@ class ProtocolRule(object):
     def enabled(self):
         """
         Gets the enabled of this ProtocolRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :return: The enabled of this ProtocolRule.
         :rtype: bool
@@ -63,7 +63,7 @@ class ProtocolRule(object):
     def enabled(self, enabled):
         """
         Sets the enabled of this ProtocolRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :param enabled: The enabled of this ProtocolRule.
         :type: bool

--- a/purity_fb/models/smb_rule.py
+++ b/purity_fb/models/smb_rule.py
@@ -40,7 +40,7 @@ class SmbRule(object):
         'acl_mode': 'acl_mode'
     }
 
-    def __init__(self, enabled=False, acl_mode='shared'):
+    def __init__(self, enabled=None, acl_mode=None):
         """
         SmbRule - a model defined in Swagger
         """
@@ -57,7 +57,7 @@ class SmbRule(object):
     def enabled(self):
         """
         Gets the enabled of this SmbRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :return: The enabled of this SmbRule.
         :rtype: bool
@@ -68,7 +68,7 @@ class SmbRule(object):
     def enabled(self, enabled):
         """
         Sets the enabled of this SmbRule.
-        is the protocol enabled?
+        is the protocol enabled? Default false when creating a new rule
 
         :param enabled: The enabled of this SmbRule.
         :type: bool
@@ -80,7 +80,7 @@ class SmbRule(object):
     def acl_mode(self):
         """
         Gets the acl_mode of this SmbRule.
-        SMB ACL mode
+        SMB ACL mode. Default shared when creating a new rule.
 
         :return: The acl_mode of this SmbRule.
         :rtype: str
@@ -91,7 +91,7 @@ class SmbRule(object):
     def acl_mode(self, acl_mode):
         """
         Sets the acl_mode of this SmbRule.
-        SMB ACL mode
+        SMB ACL mode. Default shared when creating a new rule.
 
         :param acl_mode: The acl_mode of this SmbRule.
         :type: str


### PR DESCRIPTION
To make sure default values don't cause unwanted overwriting in updates. Add the default value into description for user to understand the default value from REST server on creation.