### PR TITLE
Fixing a small typo which prevented documentation from building.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ pages:
         - Certificates: CertificatesApi.md
         - Certificate Uses: CertificatesApi.md
         - Certificate Groups: CertificateGroupsApi.md
-        - Certificate Group Uses: CertififcateGroupsApi.md
+        - Certificate Group Uses: CertificateGroupsApi.md
         - Directory Services: DirectoryServicesApi.md
         - Directory Services Roles: DirectoryServicesApi.md
         - Directory Services Tests: DirectoryServicesApi.md


### PR DESCRIPTION
"CertificateGroupsApi" was misspelled in `mkdocs.yml`. This was
preventing readthedocs from being able to generate documentation
for the REST API v1.9.0.