### PR TITLE
Returning index.md to the `pages` list in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Pure Storage FlashBlade REST 1.9 Python SDK
 pages:
-- About:
+- Overview:
+    - Get Started: index.md
     - License: about/license.md
 - Endpoints:
     - Authentication: AuthenticationApi.md


### PR DESCRIPTION
The version of mkdocs that is used by readthedocs doesn't include all files
that are present. Instead, a file must be referenced in the `pages` list of
mkdocs.yml. Newer versions of mkdocs have different behavior, which would
allow us to achieve the desired presentation/structure in the nav...but I'm
restoring `index.md` to the `pages` list because this is just what we have
to work with.